### PR TITLE
Bug Fix - fixing context for consumer class method run

### DIFF
--- a/Classes/ScheduleJob/Consumer/JobConsumer.js
+++ b/Classes/ScheduleJob/Consumer/JobConsumer.js
@@ -7,11 +7,11 @@ class JobConsumer {
   }
 
   on(jobName) {
-    ScheduleJobEventBus.on('scheduleJob:' + jobName, this.run);
+    ScheduleJobEventBus.on('scheduleJob:' + jobName, (...args) => this.run(...args));
   }
 
   off(jobName) {
-    ScheduleJobEventBus.off('scheduleJob:' + jobName, this.run);
+    ScheduleJobEventBus.off('scheduleJob:' + jobName, (...args) => this.run(...args));
   }
 
   async complete(jobLog, result) {


### PR DESCRIPTION
use arrow function and argument spreading to keep context for consumer class run method when calling using the eventEmitter